### PR TITLE
add historization

### DIFF
--- a/.github/workflows/historization.yml
+++ b/.github/workflows/historization.yml
@@ -62,8 +62,8 @@ jobs:
     - name: Commit files
       run: |
         cd data_raw
-        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git config --local user.name "github-actions[bot]"
+        git config --local user.email "actions@users.noreply.github.com"
+        git config --local user.name "demodiffbot"
         git add --all
         git diff-index --quiet HEAD || git commit -a -m "Berlin: Add changes"
     - name: Push changes

--- a/.github/workflows/historization.yml
+++ b/.github/workflows/historization.yml
@@ -1,0 +1,74 @@
+name: Historization
+
+on:
+  workflow_dispatch:
+  #schedule:
+  #  - cron: '*/30 * * * *'
+
+jobs:
+  extract_all_raw:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Checkout demodiff/daten
+      uses: actions/checkout@v3
+      with:
+        repository: demodiff/daten
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: data_raw
+    - name: Checkout demodiff_berlin
+      uses: actions/checkout@v3
+      with:
+        repository: demodiff/berlin
+        path: demodiff_berlin
+        fetch-depth: 0
+    
+    - name: Install git
+      run: sudo apt-get install -y git
+      
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Extract all raw
+      run: |
+        python scripts/extract_all_raw.py
+    
+    - name: Remove duplicates
+      run: | 
+        sudo snap install fclones
+        fclones group data_raw/ > dupes.txt
+        cat dupes.txt
+        fclones remove < dupes.txt
+    
+    - name: Create summary
+      run: |
+        python scripts/create_summary.py
+    
+    - name: Commit files
+      run: |
+        cd data_raw
+        git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+        git config --local user.name "github-actions[bot]"
+        git add --all
+        git diff-index --quiet HEAD || git commit -a -m "Berlin: Add changes"
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        repository: demodiff/daten
+        directory: data_raw
+        github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 pandas
+GitPython

--- a/scripts/create_summary.py
+++ b/scripts/create_summary.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 import os
 import glob
 import re

--- a/scripts/create_summary.py
+++ b/scripts/create_summary.py
@@ -1,0 +1,62 @@
+import os
+import glob
+import re
+from datetime import datetime
+import json
+import pytz
+
+def parse_filename(filename):
+    pattern = r"(\d{8}_\d{6})_(\w+)\.json"
+    match = re.match(pattern, filename)
+    
+    if match:
+        datetime_str = match.group(1)
+        sha_hash = match.group(2)
+
+        # Parse datetime string into datetime object
+        datetime_obj = datetime.strptime(datetime_str, "%Y%m%d_%H%M%S")
+
+        return datetime_obj, sha_hash
+    else:
+        return None
+
+def create_summary(repo_path, file_path, raw_output_path):
+    print(repo_path)
+    
+    # Get a list of all .json files in the folder
+    json_files = glob.glob("*.json", root_dir=raw_output_path)
+
+    file_dict = {}
+    for file in json_files:
+        filename = os.path.basename(file)
+        result = parse_filename(filename)
+
+        if result:
+            datetime_obj, sha_hash = result
+
+            # Convert datetime to CET/CEST (Europe/Berlin)
+            timezone = pytz.timezone('Europe/Berlin')
+            datetime_cet = datetime_obj.replace(tzinfo=pytz.UTC).astimezone(timezone)
+
+            # Print datetime as a single string in ISO 8601 format
+            datetime_iso = datetime_cet.isoformat()
+
+            file_dict[datetime_iso] = filename
+
+        else:
+            print("Filename", filename, "does not match the expected pattern.")
+
+    # Output the file_dict to a JSON file
+    json_output = os.path.join(raw_output_path, "summary", "file_dict.json")
+    os.makedirs(os.path.dirname(json_output), exist_ok=True)
+    with open(json_output, 'w') as file:
+        json.dump(file_dict, file, sort_keys=True)
+
+    print("JSON file generated:", json_output)
+
+if __name__ == "__main__":
+    if os.getenv("CI") == 'true':
+        create_summary('demodiff_berlin', 'data/results.json', 'data_raw')
+    else:
+        from settings import repo_path, file_path, perform_output_dir_cleanup, raw_output_path
+        create_summary(repo_path, file_path, raw_output_path)

--- a/scripts/extract_all_raw.py
+++ b/scripts/extract_all_raw.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+
 import os
 from datetime import datetime
 

--- a/scripts/extract_all_raw.py
+++ b/scripts/extract_all_raw.py
@@ -1,0 +1,57 @@
+import os
+from datetime import datetime
+
+import git
+
+
+def extract_all_raw(repo_path, file_path, raw_output_path, perform_output_dir_cleanup=False):
+    # Create the output directory if it doesn't exist
+    os.makedirs(raw_output_path, exist_ok=True)
+
+    # Perform output directory cleanup if enabled
+    if perform_output_dir_cleanup:
+        # Empty the output directory
+        for file_name in os.listdir(raw_output_path):
+            file_path = os.path.join(raw_output_path, file_name)
+            if os.path.isfile(file_path):
+                os.remove(file_path)
+
+    # Open the repository
+    repo = git.Repo(repo_path)
+
+    # Access the main branch
+    branch = repo.branches['main']
+
+    # Iterate over the commits on the main branch
+    for commit in repo.iter_commits(branch):
+        try:
+            # Retrieve file contents from the commit
+            file_contents = commit.tree[file_path].data_stream.read().decode('utf-8')
+
+            # Extract commit metadata
+            commit_timestamp = datetime.fromtimestamp(commit.committed_date)
+            commit_hash = commit.hexsha
+
+            # Generate the filename using an f-string
+            filename = f"{commit_timestamp.strftime('%Y%m%d_%H%M%S')}_{commit_hash}.json"
+            file_output_path = os.path.join(raw_output_path, filename)
+
+            # Print metadata
+            print(f'Commit: {commit.hexsha}')
+            print(f'Timestamp: {commit_timestamp.isoformat()}')
+            print(f'Output file: {file_output_path}')
+            print('----------------------------------------')
+
+            # Write the file contents to the output file
+            with open(file_output_path, 'w') as output_file:
+                output_file.write(file_contents)
+        except KeyError:
+            # The file is not found in the commit
+            print(f'File {file_path} not found in {commit.hexsha}')
+
+if __name__ == "__main__":
+    if os.getenv("CI") == 'true':
+        extract_all_raw('demodiff_berlin', 'data/results.json', 'data_raw')
+    else:
+        from settings import repo_path, file_path, perform_output_dir_cleanup, raw_output_path
+        extract_all_raw(repo_path, file_path, raw_output_path, perform_output_dir_cleanup)


### PR DESCRIPTION
Add a workflow which checks out a copy of the repo, browses all of the git history for the different revisions of the `results.json` and puts them in a separate repo for further use.

The idea behind this is to conserve the raw data as it was received from the source, without any transformations, and to store it in a way that can easily be consumed/accessed for other use cases and projects.