### PR TITLE
Feature: Slim historization

### DIFF
--- a/.github/workflows/historization_slim.yml
+++ b/.github/workflows/historization_slim.yml
@@ -1,0 +1,74 @@
+name: Historization (slim)
+
+on:
+  workflow_dispatch:
+  #schedule:
+  #  - cron: '*/30 * * * *'
+
+jobs:
+  extract_all_raw:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Checkout demodiff/daten
+      uses: actions/checkout@v3
+      with:
+        repository: demodiff/daten
+        token: ${{ secrets.PAT }}
+        path: data_raw
+    - name: Checkout demodiff_berlin
+      uses: actions/checkout@v3
+      with:
+        repository: demodiff/berlin
+        path: demodiff_berlin
+        fetch-depth: 0
+    
+    - name: Install git
+      run: sudo apt-get install -y git
+      
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v3
+      with:
+        python-version: "3.10"
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install flake8 pytest
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Extract all raw
+      run: |
+        python scripts/extract_all_raw.py
+    
+    - name: Remove duplicates
+      run: | 
+        sudo snap install fclones
+        fclones group data_raw/ > dupes.txt
+        cat dupes.txt
+        fclones remove < dupes.txt
+    
+    - name: Create summary
+      run: |
+        python scripts/create_summary.py
+    
+    - name: Commit files
+      run: |
+        cd data_raw
+        git config --local user.email "actions@users.noreply.github.com"
+        git config --local user.name "demodiffbot"
+        git add --all
+        git diff-index --quiet HEAD || git commit -a -m "Berlin: Add changes"
+    - name: Push changes
+      uses: ad-m/github-push-action@master
+      with:
+        repository: demodiff/daten
+        directory: data_raw
+        github_token: ${{ secrets.PAT }}

--- a/.github/workflows/historization_slim.yml
+++ b/.github/workflows/historization_slim.yml
@@ -19,12 +19,6 @@ jobs:
         repository: demodiff/daten
         token: ${{ secrets.PAT }}
         path: data_raw
-    - name: Checkout demodiff_berlin
-      uses: actions/checkout@v3
-      with:
-        repository: demodiff/berlin
-        path: demodiff_berlin
-        fetch-depth: 0
       
     - name: Set up Python 3.10
       uses: actions/setup-python@v3
@@ -35,7 +29,6 @@ jobs:
       run: |
         git show HEAD:data/results.json > data_raw/berlin/$(git show -s --format=%cd --date=format:'%Y%m%d_%H%M%S')_$(git rev-parse HEAD).json
 
-    
     - name: Remove duplicates
       run: | 
         sudo snap install fclones
@@ -54,7 +47,7 @@ jobs:
         git config --local user.name "demodiffbot"
         git add --all
         git diff-index --quiet HEAD || git commit -a -m "Berlin: Add changes"
-        
+
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/historization_slim.yml
+++ b/.github/workflows/historization_slim.yml
@@ -44,9 +44,11 @@ jobs:
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Extract all raw
+
+    - name: Historize latest results.json
       run: |
-        python scripts/extract_all_raw.py
+        git show HEAD:data/results.json > data_raw/berlin/$(git show -s --format=%cd --date=format:'%Y%m%d_%H%M%S')_$(git rev-parse HEAD).json
+
     
     - name: Remove duplicates
       run: | 

--- a/.github/workflows/historization_slim.yml
+++ b/.github/workflows/historization_slim.yml
@@ -8,7 +8,7 @@ on:
       - completed
 
 jobs:
-  extract_all_raw:
+  add_latest_results_if_changed:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/historization_slim.yml
+++ b/.github/workflows/historization_slim.yml
@@ -30,17 +30,6 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
 
     - name: Historize latest results.json
       run: |
@@ -65,6 +54,7 @@ jobs:
         git config --local user.name "demodiffbot"
         git add --all
         git diff-index --quiet HEAD || git commit -a -m "Berlin: Add changes"
+        
     - name: Push changes
       uses: ad-m/github-push-action@master
       with:

--- a/.github/workflows/historization_slim.yml
+++ b/.github/workflows/historization_slim.yml
@@ -2,8 +2,10 @@ name: Historization (slim)
 
 on:
   workflow_dispatch:
-  #schedule:
-  #  - cron: '*/30 * * * *'
+  workflow_run:
+    workflows: ["scraper"]
+    types:
+      - completed
 
 jobs:
   extract_all_raw:

--- a/.github/workflows/historization_slim.yml
+++ b/.github/workflows/historization_slim.yml
@@ -25,9 +25,6 @@ jobs:
         repository: demodiff/berlin
         path: demodiff_berlin
         fetch-depth: 0
-    
-    - name: Install git
-      run: sudo apt-get install -y git
       
     - name: Set up Python 3.10
       uses: actions/setup-python@v3

--- a/scripts/create_summary.py
+++ b/scripts/create_summary.py
@@ -22,8 +22,7 @@ def parse_filename(filename):
     else:
         return None
 
-def create_summary(repo_path, file_path, raw_output_path):
-    print(repo_path)
+def create_summary(raw_output_path):
     
     # Get a list of all .json files in the folder
     json_files = glob.glob("*.json", root_dir=raw_output_path)
@@ -58,7 +57,7 @@ def create_summary(repo_path, file_path, raw_output_path):
 
 if __name__ == "__main__":
     if os.getenv("CI") == 'true':
-        create_summary('demodiff_berlin', 'data/results.json', 'data_raw/berlin')
+        create_summary('data_raw/berlin')
     else:
-        from settings import repo_path, file_path, perform_output_dir_cleanup, raw_output_path
-        create_summary(repo_path, file_path, raw_output_path)
+        from settings import raw_output_path
+        create_summary(raw_output_path)


### PR DESCRIPTION
The historization that is already present always browses the whole git history and creates a file for each commit, just to deduplicate them before committing.
This is unneccesary resource intensive for a regular workflow (however, it is useful for the initial reconstruction). The workflow in this PR only takes the latest `results.json`, performs deduplication and then commits if the file is different from the previous version.